### PR TITLE
remove attempt to preserve timestamps when exporting analysis - not w…

### DIFF
--- a/bcl2fastq_pipeline/bcl2fastq_pipeline/afterFastq.py
+++ b/bcl2fastq_pipeline/bcl2fastq_pipeline/afterFastq.py
@@ -922,10 +922,9 @@ def full_align(config):
         #push analysis folder
         analysis_export_dir = os.path.join(config.get("Paths","analysisDir"),"{}_{}".format(p,config.get("Options","runID").split("_")[0]))
 
-        cmd = "cp -rvP --preserve=timestamps {src}/ {dst} && touch {transfer_done}".format(
+        cmd = "cp -rv {src}/ {dst} ".format(
             src = analysis_dir,
             dst = analysis_export_dir,
-            transfer_done = os.path.join(analysis_export_dir,"transfer.done")
         )
         subprocess.check_call(cmd,shell=True)
     os.chdir(old_wd)


### PR DESCRIPTION
…orking. Omit touching transfer.done file - no need for this when transfers are not done as background job.